### PR TITLE
[2.0] Fix doc generation warnings

### DIFF
--- a/docs/documentation/cameras/how-to-execute-robot-camera-calibration.rst
+++ b/docs/documentation/cameras/how-to-execute-robot-camera-calibration.rst
@@ -82,7 +82,7 @@ Now repeat the following cycle for every pose:  
 
 This request should be sent from the robot using the provided
 calibration program. This program can be found under the  **Files** tab
-of the Pickit web interface or under :ref:`robot-integrations`.
+of the Pickit web interface or shipped by the respective robot integration.
 
 After each successful collection of such a pair of transformations, the
 interface looks as follows:
@@ -109,7 +109,7 @@ Single pose calibration
 -----------------------
 
 Some restrictive conditions on using single pose calibration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #. Single pose calibration can only be executed when **the camera is not
    mounted on the robot**.
@@ -125,7 +125,7 @@ If one of these conditions can not be met, you will need to perform
 calibration with :ref:`calibration-multi-poses`.
 
 Step 1: Install calibration plate
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Go to the **Calibration** tab of the Pickit user interface and
 select **Single pose calibration**.
@@ -138,8 +138,8 @@ camera (the “Plate visible” indicator should be green).
 Preferably, the calibration plate is as much as possible in the
 center of the region where the actual picking will take place.
 
-.. rubric:: Step 2: Define helper transformation
-   :name: helper_transformation
+Step 2: Define helper transformation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The **helper transformation** is the transformation between the flange
 frame of the robot and the calibration plate frame. On the figure below
@@ -173,7 +173,7 @@ is mounted directly to the robot flange:
 -  **Yaskawa:** 0 \| -45°
 
 Step 3: Send a calibration request from the robot
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 At this point, a request for calibration should be sent.
 
@@ -221,7 +221,7 @@ Recalibration is only required when the camera is moved or rotated with
 respect to the robot. 
 
 Universal Robots
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 If you have a Universal Robots robot, you can additionally visualize a
 **virtual 3D robot**, which should make it easier to verify the

--- a/docs/documentation/pattern/explaining-the-pattern-detection-parameters.rst
+++ b/docs/documentation/pattern/explaining-the-pattern-detection-parameters.rst
@@ -94,10 +94,10 @@ ellipse). One can specify:
    internal and external contours.
 -  The **3D matching tolerance**, used to determine the points that
    confirm flat regions.
-.. image:: /assets/images/Documentation/3d-matching-tolerance.png
+   .. image:: /assets/images/Documentation/3d-matching-tolerance.png
 -  The **2D matching tolerance**, used to determine the points that
    confirm the object model.
-.. image:: /assets/images/Documentation/3d-matching-tolerance.png
+   .. image:: /assets/images/Documentation/3d-matching-tolerance.png
 
 
 Define dimensions and orientation of objects

--- a/docs/documentation/picking/check-collisions-with.rst
+++ b/docs/documentation/picking/check-collisions-with.rst
@@ -1,7 +1,7 @@
 .. _check-collision-with:
 
-Check collisions with
----------------------
+Check collisions with the robot tool
+------------------------------------
 
 This setting allows you to discard pick frames that would result in
 collision. The pick frames can checked for possible collision with the
@@ -18,8 +18,8 @@ unpickable.
 Bin
 ~~~
 
-This option checks if the tool is colliding with the Region of Interest
-box. If set the tool is not allowed to hit the sides or bottom of the
+This option checks if the tool is colliding with the Region of Interest.
+If set the tool is not allowed to hit the sides or bottom of the
 region of interest box. If the Region of interest box is set to similar
 dimensions as the actual bin, this option is checking for collisions
 with the actual bin. A rule of thumb for this to work properly is to set
@@ -32,7 +32,7 @@ Other objects
 ~~~~~~~~~~~~~
 
 This option checks if the tool is colliding with other objects that are
-visible in the region of interest. As seen in the image below the object
+visible in the Region of Interest. As seen in the image below the object
 is not safe to pick because there is another object on top and the tool
 would collide with this other object.
 

--- a/docs/documentation/picking/index.rst
+++ b/docs/documentation/picking/index.rst
@@ -83,8 +83,8 @@ unpickable and will not be sent to the robot.
     maximum-angle-between-pick-and-reference-frame-zaxis
     maximum-angle-between-pick-frame-zaxis-and-surface-normal
 
-Check collisions with
-~~~~~~~~~~~~~~~~~~~~~
+Check collisions with the robot tool
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pickit also checks for possible collisions in the actual scene. For
 this, first a robot tool needs to be modeled. And second you have to define with what you want to check

--- a/docs/faq/robot-programming/how-can-i-get-a-better-bin-picking-experience.rst
+++ b/docs/faq/robot-programming/how-can-i-get-a-better-bin-picking-experience.rst
@@ -31,12 +31,12 @@ Pickit, while others relate to your hardware setup.
 
    .. image:: /assets/images/faq/Ordering-center-part.png
 
--  Enable :ref:`check-collision-with`
+-  Enable :ref:`checking collisions <check-collision-with>`
    between tool and bin, and between tool and other objects in the bin.
    
    .. image:: /assets/images/faq/Collision-prevention.png
 
--  Enforce :ref:`enforce-alignment-of-pick-frame-orientation`
+-  :ref:`enforce-alignment-of-pick-frame-orientation`
    to constrain the approach direction and orientation. When enforcing
    alignment constraints it's useful to enable the bin avoidance
    strategy to improve reachability of objects close to the bin borders.

--- a/docs/robot-integrations/ros/index.rst
+++ b/docs/robot-integrations/ros/index.rst
@@ -199,8 +199,8 @@ TF tree
 
 Pickit uses two fixed robot frame names that are important for you if you want to connect your robot’s tf tree with Pickit’s tf tree. A simplified version of the Pickit tf tree for both camera fixed and camera on the robot looks like the following:
 
-Camera fixed
-~~~~~~~~~~~~
+Camera fixed TF tree
+~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -211,8 +211,8 @@ Camera fixed
            +              robot-camera-calibration
     pickit/robot_base +------------------------------> camera/camera_link
 
-Camera on robot
-~~~~~~~~~~~~~~~
+Camera on robot TF tree
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 

--- a/docs/robot-integrations/staubli/index.rst
+++ b/docs/robot-integrations/staubli/index.rst
@@ -1,4 +1,4 @@
-.. _Stäubli:
+.. _staubli:
 
 Setting up Pickit with Stäubli
 ===============================

--- a/docs/robot-integrations/universal-robots/urscript/index.rst
+++ b/docs/robot-integrations/universal-robots/urscript/index.rst
@@ -75,6 +75,13 @@ Once unpacked, the UR_Pickit folder contains the following files:
 - ``urmagic_upload_programs.sh``: This program takes care of the automatic uploading of all Pickit related files to the UR controller.
 
 The UR_Pickit folder also contains a few folders, each one corresponding to a different **Polyscope** software version, containing robot programs that use the mentioned ASCII files.
+A list of available functions can be found here:
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+
+    the_pickit_functions_cheat_sheet
 
 .. warning::
     Modifying **pickit\_communication**, **pickit\_functions** or **Pickit\_transformations** should only be considered after talking to a **Pickit support engineer**. 

--- a/docs/robot-integrations/universal-robots/urscript/the_pickit_functions_cheat_sheet.rst
+++ b/docs/robot-integrations/universal-robots/urscript/the_pickit_functions_cheat_sheet.rst
@@ -11,33 +11,25 @@ The Pickit functions cheat sheet
 Pickit provides many functions to script your Pickit application to a
 success. Underneath we provide an overview of the provided functions:
 
-`pickit\_is\_running() <#pickit_is_running>`__,
-`pickit\_can\_calibrate() <#pickit_can_calibrate>`__,
-`pickit\_save\_scene() <#pickit_save_scene>`__,
-`pickit\_find\_calib\_plate() <#pickit_find_calib_plate>`__,
-`pickit\_configure(setup,product) <#pickit_configure>`__,
-`pickit\_look\_for\_object() <#pickit_look_for_object>`__,
-`pickit\_next\_object() <#pickit_next_object>`__,
-`pickit\_has\_response() <#pickit_has_response>`__,
-`pickit\_object\_found() <#pickit_object_found>`__,
-`pickit\_no\_image\_captured() <#pickit_no_image_captured>`__,
-`pickit\_remaining\_objects() <#pickit_remaining_objects>`__,
-`pickit\_get\_pose() <#pickit_get_pose>`__
+`pickit\_is\_running() <pickit\_is\_running()_>`__,
+`pickit\_can\_calibrate() <pickit\_can\_calibrate()_>`__,
+`pickit\_save\_scene() <pickit\_save\_scene()_>`__,
+`pickit\_find\_calib\_plate() <pickit\_find\_calib\_plate()_>`__,
+`pickit\_configure(setup,product) <pickit\_configure(setup, product)_>`__,
+`pickit\_look\_for\_object() <pickit\_look\_for\_object()_>`__,
+`pickit\_next\_object() <pickit\_next\_object()_>`__,
+`pickit\_has\_response() <pickit\_has\_response()_>`__,
+`pickit\_object\_found() <pickit\_object\_found()_>`__,
+`pickit\_no\_image\_captured() <pickit\_no\_image\_captured()_>`__,
+`pickit\_remaining\_objects() <pickit\_remaining\_objects()_>`__,
+`pickit\_get\_pose() <pickit\_get\_pose()_>`__
 
 Intro
 -----
 
-.. raw:: html
-
-   <div>
-
 We differentiate two different kinds of functions:
 
-.. raw:: html
-
-   </div>
-
--  **Blocking functions: **\ These functions send a command to Pickit
+-  **Blocking functions:** These functions send a command to Pickit
    and waits until a response is received. 
 -  **Stopping functions:** These functions force the robot program to
    stop in case it returns false. Note that the return value is never


### PR DESCRIPTION
Fixes all warnings except this one:
```
/docs/robot-integrations/kuka/kuka_krc_example_program.rst: WARNING: document isn't included in any toctree
```